### PR TITLE
Alternative syntax with named variables

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -104,6 +104,8 @@ endif
 VFILES:=config.v\
   config_tactics.v\
   syntax.v\
+  altsyntax.v\
+  syntaxes.v\
   tt.v\
   ett.v\
   ptt.v\

--- a/src/README.md
+++ b/src/README.md
@@ -9,7 +9,12 @@ The purpose here is to state and prove theorems about the sanity of different ty
 ### Theories
 * `syntax.v`: Syntax of our type theories with type annotations,
 * `ett.v`: Typing rules of ETT (Extensional Type Theory) using syntax from `syntax.v`,
-* `ptt.v`: Typing rules of PTT (Paranoid Type Theory) using the same syntax, it has more premises to make sure everything is sane.
+* `ptt.v`: Typing rules of PTT (Paranoid Type Theory) using the same
+  syntax, it has more premises to make sure everything is sane.
+
+### Alternative syntax
+* `altsyntax.v`: Syntax of type theory with named variables,
+* `syntaxes.v`: Translation from `altsyntax` to `syntax`.
 
 ### Admissibility in PTT
 * `ptt_tactics.v`: Tactics designed to prove judgements in PTT,

--- a/src/_CoqProject
+++ b/src/_CoqProject
@@ -3,6 +3,10 @@
 config.v
 config_tactics.v
 syntax.v
+altsyntax.v
+
+syntaxes.v
+
 tt.v
 ett.v
 ptt.v

--- a/src/altsyntax.v
+++ b/src/altsyntax.v
@@ -1,0 +1,52 @@
+(* Alternative syntax with names for variables *)
+
+Require Import String.
+
+Definition variable := string.
+
+Inductive context : Type :=
+| ctxempty : context
+| ctxextend : context -> variable -> type -> context
+
+with type : Type :=
+| Prod : variable -> type -> type -> type
+| Id : type -> term -> term -> type
+(* | Subst : type -> substitution -> type *)
+| Empty : type
+| Unit : type
+| Bool : type
+| SimProd : type -> type -> type
+| Uni : nat -> type
+(* TODO: Add a Prop universe *)
+| El : term -> type
+
+with term : Type :=
+| var : variable -> term
+| lam : variable -> type -> type -> term -> term
+| app : term -> variable -> type -> type -> term -> term
+| refl : type -> term -> term
+| j : type -> term -> variable -> variable -> type -> term -> term -> term -> term
+(* | subst : term -> substitution -> term *)
+| exfalso : type -> term -> term
+| unit : term
+| true : term
+| false : term
+| cond : variable -> type -> term -> term -> term -> term
+| pair : type -> type -> term -> term -> term
+| proj1 : type -> type -> term -> term
+| proj2 : type -> type -> term -> term
+| uniProd : nat -> variable -> term -> term -> term
+| uniId : nat -> term -> term -> term -> term
+| uniEmpty : nat -> term
+| uniUnit : nat -> term
+| uniBool : nat -> term
+| uniSimProd : nat -> term -> term -> term
+| uniUni : nat -> term.
+
+(* with substitution : Type := *)
+(* (* | sbzero : type -> term -> substitution *) *)
+(* (* | sbweak : type -> substitution *) *)
+(* (* | sbshift : type -> substitution -> substitution *) *)
+(* | sbvar : type -> variable -> term -> substitution *)
+(* | sbid : substitution *)
+(* | sbcomp : substitution -> substitution -> substitution. *)

--- a/src/altsyntax.v
+++ b/src/altsyntax.v
@@ -11,7 +11,6 @@ Inductive context : Type :=
 with type : Type :=
 | Prod : variable -> type -> type -> type
 | Id : type -> term -> term -> type
-(* | Subst : type -> substitution -> type *)
 | Empty : type
 | Unit : type
 | Bool : type
@@ -26,7 +25,6 @@ with term : Type :=
 | app : term -> variable -> type -> type -> term -> term
 | refl : type -> term -> term
 | j : type -> term -> variable -> variable -> type -> term -> term -> term -> term
-(* | subst : term -> substitution -> term *)
 | exfalso : type -> term -> term
 | unit : term
 | true : term
@@ -43,10 +41,14 @@ with term : Type :=
 | uniSimProd : nat -> term -> term -> term
 | uniUni : nat -> term.
 
-(* with substitution : Type := *)
-(* (* | sbzero : type -> term -> substitution *) *)
-(* (* | sbweak : type -> substitution *) *)
-(* (* | sbshift : type -> substitution -> substitution *) *)
-(* | sbvar : type -> variable -> term -> substitution *)
-(* | sbid : substitution *)
-(* | sbcomp : substitution -> substitution -> substitution. *)
+Open Scope string_scope.
+
+Notation "'·'" := (ctxempty).
+Notation "'Π' ( x 'in' A ) → B" := (Prod x A B) (at level 20).
+Notation "A → B" := (Prod "_" A B) (at level 20).
+Notation "u ≡ v 'in' A" := (Id A u v) (at level 10).
+(* Notation "'λ' x 'in' A ⇒ v 'to' B" := (lam x A B v) (at level 19). *)
+(* Notation "u '@' [ x 'in' A → B ] v" := (app u x A B v) (at level 19). *)
+(* Notation "u '@' [ A → B ] v" := (app u "_" A B v) (at level 19). *)
+
+Close Scope string_scope.

--- a/src/negfunext.v
+++ b/src/negfunext.v
@@ -6,9 +6,13 @@
 Require config.
 Require Import config_tactics.
 
-Require Import syntax.
+Require syntax.
 Require Import tt.
 Require Import checking_tactics.
+
+Require altsyntax.
+Require Import Strings.String.
+Require Import syntaxes.
 
 (* Source type theory *)
 Module Stt.
@@ -64,6 +68,8 @@ Module Ttt.
 End Ttt.
 
 Section Translation.
+
+Import syntax.
 
 Context `{configReflection : config.Reflection}.
 Context `{configSimpleProducts : config.SimpleProducts}.
@@ -1174,3 +1180,47 @@ Proof.
 Qed.
 
 End Translation.
+
+(*! In Stt we have the negation of funext !*)
+Section Negation.
+
+Import altsyntax.
+Open Scope string_scope.
+
+(* We will negate (and thus instantiate) funext on Unit -> Unit only *)
+
+Definition arrow := Prod "_" Unit Unit.
+
+Definition funextUnit :=
+  Prod "f" arrow
+       (Prod "g" arrow
+             (Prod "_" (Prod "x" Unit
+                             (Id Unit
+                                 (app (var "f") "_" Unit Unit (var "x"))
+                                 (app (var "g") "_" Unit Unit (var "x"))))
+                   (Id arrow (var "f") (var "g")))).
+
+(* We will prove that [funextUnit] -> true = false by applying the funext
+   to two identity functions with different booleans.
+*)
+Definition idUnit := lam "x" Unit Unit (var "x").
+Definition idTrue := pair arrow Bool idUnit true.
+Definition idFalse := pair arrow Bool idUnit false.
+
+Definition _funextUnit := totype nil funextUnit.
+Definition trans_funextUnit :=
+  match _funextUnit with
+  | inl t => trans_type t
+  | _ => syntax.Empty (* does not happen! *)
+  end.
+
+Definition funextApplied : syntax.term.
+Proof.
+  pose (t := trans_funextUnit).
+  unfold trans_funextUnit in t. unfold _funextUnit in t.
+  simpl in t.
+
+  (* Maybe we should translate back to altsyntax... *)
+Abort.
+
+End Negation.

--- a/src/negfunext.v
+++ b/src/negfunext.v
@@ -1189,16 +1189,32 @@ Open Scope string_scope.
 
 (* We will negate (and thus instantiate) funext on Unit -> Unit only *)
 
-Definition arrow := Prod "_" Unit Unit.
+Definition arrow := Unit → Unit.
+
+(* Definition funextUnit := *)
+(*   Π ("f" in arrow) → *)
+(*     Π ("g" in arrow) → *)
+(*       (Π ("x" in Unit) → *)
+(*          (var "f") @[Unit → Unit] (var "x") ≡ (var "g") @[Unit → Unit] (var "x") in Unit) → *)
+(*       (var "f") ≡ (var "g") in arrow. *)
 
 Definition funextUnit :=
-  Prod "f" arrow
-       (Prod "g" arrow
-             (Prod "_" (Prod "x" Unit
-                             (Id Unit
-                                 (app (var "f") "_" Unit Unit (var "x"))
-                                 (app (var "g") "_" Unit Unit (var "x"))))
-                   (Id arrow (var "f") (var "g")))).
+  Π ("f" in arrow) →
+    Π ("g" in arrow) →
+      (Π ("x" in Unit) →
+         ((app (var "f") "_" Unit Unit (var "x"))
+       ≡ (app (var "g") "_" Unit Unit (var "x"))
+       in Unit)) →
+      ((var "f") ≡ (var "g") in arrow).
+
+(* Definition funextUnit := *)
+(*   Prod "f" arrow *)
+(*        (Prod "g" arrow *)
+(*              (Prod "_" (Prod "x" Unit *)
+(*                              (Id Unit *)
+(*                                  (app (var "f") "_" Unit Unit (var "x")) *)
+(*                                  (app (var "g") "_" Unit Unit (var "x")))) *)
+(*                    (Id arrow (var "f") (var "g")))). *)
 
 (* We will prove that [funextUnit] -> true = false by applying the funext
    to two identity functions with different booleans.
@@ -1222,5 +1238,7 @@ Proof.
 
   (* Maybe we should translate back to altsyntax... *)
 Abort.
+
+Close Scope string_scope.
 
 End Negation.

--- a/src/syntaxes.v
+++ b/src/syntaxes.v
@@ -1,0 +1,348 @@
+Require syntax altsyntax.
+Require Import List String.
+
+Definition named_ctx := list altsyntax.variable.
+
+Open Scope type_scope.
+
+Inductive Error := error.
+
+(* Lookup operation to convert a string variable into a de Bruijn index *)
+Fixpoint lookup_n (Gx : named_ctx) (x : altsyntax.variable) (n : nat) : nat + Error :=
+  match Gx with
+  | nil => inr error
+  | y :: Gx =>
+    match string_dec x y with
+    | left eq => inl n
+    | right neq => lookup_n Gx x (S n)
+    end
+  end.
+
+Definition lookup Gx x : nat + Error := lookup_n Gx x 0.
+
+
+(* First we translate altsyntax back to syntax *)
+Fixpoint totype (Gx : named_ctx) (A : altsyntax.type) : syntax.type + Error :=
+  match A with
+  | altsyntax.Prod x A B =>
+    match totype Gx A with
+    | inl A' =>
+      match totype (x :: Gx) B with
+      | inl B' => inl (syntax.Prod A' B')
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.Id A u v =>
+    match totype Gx A with
+    | inl A' =>
+      match toterm Gx u with
+      | inl u' =>
+        match toterm Gx v with
+        | inl v' => inl (syntax.Id A' u' v')
+        | inr _ => inr error
+        end
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  (* | altsyntax.Subst A sbs => *)
+  (*   match totype Gx A with *)
+  (*   | inl A' => *)
+  (*     match tosubst sbs with *)
+  (*     | inl sbs' => inl (syntax.Subst A' sbs') *)
+  (*     | inr _ => inr error *)
+  (*     end *)
+  (*   | inr _ => inr error *)
+  (*   end *)
+
+  | altsyntax.Empty => inl syntax.Empty
+
+  | altsyntax.Unit => inl syntax.Unit
+
+  | altsyntax.Bool => inl syntax.Bool
+
+  | altsyntax.SimProd A B =>
+    match totype Gx A with
+    | inl A' =>
+      match totype Gx B with
+      | inl B' => inl (syntax.SimProd A' B')
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.Uni n => inl (syntax.Uni n)
+
+  | altsyntax.El a =>
+    match toterm Gx a with
+    | inl a' => inl (syntax.El a')
+    | inr _ => inr error
+    end
+
+  end
+
+with toterm (Gx : named_ctx) (u : altsyntax.term) : syntax.term + Error :=
+  match u with
+  | altsyntax.var x =>
+    match lookup Gx x with
+    | inl n => inl (syntax.var n)
+    | inr _ => inr error
+    end
+
+  | altsyntax.lam x A B v =>
+    match totype Gx A with
+    | inl A' =>
+      match totype (x :: Gx) B with
+      | inl B' =>
+        match toterm (x :: Gx) v with
+        | inl v' => inl (syntax.lam A' B' v')
+        | inr _ => inr error
+        end
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.app u x A B v =>
+    match toterm Gx u with
+    | inl u' =>
+      match totype Gx A with
+      | inl A' =>
+        match totype (x :: Gx) B with
+        | inl B' =>
+          match toterm Gx v with
+          | inl v' => inl (syntax.app u' A' B' v')
+          | inr _ => inr error
+          end
+        | inr _ => inr error
+        end
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.refl A u =>
+    match totype Gx A with
+    | inl A' =>
+      match toterm Gx u with
+      | inl u' => inl (syntax.refl A' u')
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.j A u y e C w v p =>
+    match totype Gx A with
+    | inl A' =>
+      match toterm Gx u with
+      | inl u' =>
+        match totype (e :: y :: Gx) C with
+        | inl C' =>
+          match toterm Gx w with
+          | inl w' =>
+            match toterm Gx v with
+            | inl v' =>
+              match toterm Gx p with
+              | inl p' => inl (syntax.j A' u' C' w' v' p')
+              | inr _ => inr error
+              end
+            | inr _ => inr error
+            end
+          | inr _ => inr error
+          end
+        | inr _ => inr error
+        end
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  (* | altsyntax.subst u sbs => *)
+  (*   match toterm Gx u with *)
+  (*   | inl u' => *)
+  (*     match tosubst sbs with *)
+  (*     | inl sbs' => inl (syntax.subst u' sbs') *)
+  (*     | inr _ => inr error *)
+  (*     end *)
+  (*   | inr _ => inr error *)
+  (*   end *)
+
+  | altsyntax.exfalso A u =>
+    match totype Gx A with
+    | inl A' =>
+      match toterm Gx u with
+      | inl u' => inl (syntax.exfalso A' u')
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.unit => inl (syntax.unit)
+
+  | altsyntax.true => inl (syntax.true)
+
+  | altsyntax.false => inl (syntax.false)
+
+  | altsyntax.cond x C u v w =>
+    match totype (x :: Gx) C with
+    | inl C' =>
+      match toterm Gx u with
+      | inl u' =>
+        match toterm Gx v with
+        | inl v' =>
+          match toterm Gx w with
+          | inl w' => inl (syntax.cond C' u' v' w')
+          | inr _ => inr error
+          end
+        | inr _ => inr error
+        end
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.pair A B u v =>
+    match totype Gx A with
+    | inl A' =>
+      match totype Gx B with
+      | inl B' =>
+        match toterm Gx u with
+        | inl u' =>
+          match toterm Gx v with
+          | inl v' => inl (syntax.pair A' B' u' v')
+          | inr _ => inr error
+          end
+        | inr _ => inr error
+        end
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.proj1 A B p =>
+    match totype Gx A with
+    | inl A' =>
+      match totype Gx B with
+      | inl B' =>
+        match toterm Gx p with
+        | inl p' => inl (syntax.proj1 A' B' p')
+        | inr _ => inr error
+        end
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.proj2 A B p =>
+    match totype Gx A with
+    | inl A' =>
+      match totype Gx B with
+      | inl B' =>
+        match toterm Gx p with
+        | inl p' => inl (syntax.proj2 A' B' p')
+        | inr _ => inr error
+        end
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.uniProd n x a b =>
+    match toterm Gx a with
+    | inl a' =>
+      match toterm (x :: Gx) b with
+      | inl b' => inl (syntax.uniProd n a' b')
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.uniId n a u v =>
+    match toterm Gx a with
+    | inl a' =>
+      match toterm Gx u with
+      | inl u' =>
+        match toterm Gx v with
+        | inl v' => inl (syntax.uniId n a' u' v')
+        | inr _ => inr error
+        end
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.uniEmpty n => inl (syntax.uniEmpty n)
+
+  | altsyntax.uniUnit n => inl (syntax.uniUnit n)
+
+  | altsyntax.uniBool n => inl (syntax.uniBool n)
+
+  | altsyntax.uniSimProd n a b =>
+    match toterm Gx a with
+    | inl a' =>
+      match toterm Gx b with
+      | inl b' => inl (syntax.uniSimProd n a' b')
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  | altsyntax.uniUni n => inl (syntax.uniUni n)
+
+  end.
+
+(* We won't handle explicit substitutions for now *)
+(* with tosubst (Gx : named_ctx) (sbs : altsyntax.substitution) *)
+(*   : syntax.substitution + Error := *)
+(*   match sbs with *)
+(*   | altsyntax.sbvar A x u => *)
+(*     (* Is it the right named_ctx for A? *) *)
+(*     (* Maybe we need a named_ctx for the codomain as well? *) *)
+(*     match totype Gx A with *)
+(*     | inl A' => *)
+(*       (* Same for u *) *)
+(*       match toterm Gx u with *)
+(*       | inl u' => *)
+(*         match lookup Gx x with *)
+(*         | inl n => *)
+(*           inl ((fix aux n := *)
+(*              match n with *)
+(*              | 0 => syntax.sbzero A' u' *)
+(*              | S n => syntax.sbshift ??? *)
+(*           ) n) *)
+
+(*   | altsyntax.sbid => inl (syntax.sbid) *)
+
+(*   | altsyntax.sbcomp sbs sbt => *)
+(*     match tosubst sbs with *)
+(*     | inl sbs' => *)
+(*       match tosubst sbt with *)
+(*       | inl sbt' => inl (syntax.sbcomp sbs' sbt') *)
+(*       | inr _ => inr error *)
+(*       end *)
+(*     | inr _ => inr error *)
+(*     end *)
+
+(*   end. *)
+
+Fixpoint toctx (G : altsyntax.context) : (syntax.context * named_ctx) + Error :=
+  match G with
+  | altsyntax.ctxempty => inl (syntax.ctxempty, nil)
+
+  | altsyntax.ctxextend G x A =>
+    match toctx G with
+    | inl (G', Gx) =>
+      match totype Gx A with
+      | inl A' => inl (syntax.ctxextend G' A', x :: Gx)
+      | inr _ => inr error
+      end
+    | inr _ => inr error
+    end
+
+  end.
+
+(* We might, later, consider also translating the other way around for
+   printing purposes. *)


### PR DESCRIPTION
The point of this branch is to add an alternative syntax that can be translated to the usual nameless one so that one can write terms in a legible fashion.