### PR TITLE
Cure boolean blindness

### DIFF
--- a/src/checking_tactics.v
+++ b/src/checking_tactics.v
@@ -11,6 +11,12 @@ Require Import syntax.
 Notation "'btrue'" := (Coq.Init.Datatypes.true).
 Notation "'bfalse'" := (Coq.Init.Datatypes.false).
 
+(* Configuration options for the tactics. *)
+Inductive magic_try := DoTry | DontTry.
+Inductive magic_doshelf := DoShelf | DontShelf.
+Inductive magic_dotysym := DoTysym | DontTysym.
+Inductive macic_debug := DoDebug | DontDebug.
+
 Section Checking1.
 
 (* We are as modular as can be *)
@@ -771,6 +777,11 @@ Qed.
 
 End Checking2.
 
+Ltac do_try flag :=
+  match flag with
+  | DoTry => idtac
+  | DontTry => fail "Cannot try"
+  end.
 
 Ltac cando token :=
   match token with
@@ -2918,15 +2929,15 @@ Ltac magicn try shelf tysym debug :=
 
     | _ => myfail debug
     end
-  | cando try
+  | do_try try
   ].
 
 Ltac preop := unfold Arrow in *.
 
-Ltac magic := preop ; magicn bfalse btrue btrue btrue.
-Ltac okmagic := preop ; magicn bfalse btrue btrue bfalse.
-Ltac trymagic := preop ; magicn btrue btrue btrue bfalse.
-Ltac strictmagic := preop ; magicn bfalse bfalse btrue btrue.
+Ltac magic       := preop ; magicn DontTry btrue  btrue btrue.
+Ltac okmagic     := preop ; magicn DontTry btrue  btrue bfalse.
+Ltac trymagic    := preop ; magicn DoTry   btrue  btrue bfalse.
+Ltac strictmagic := preop ; magicn DontTry bfalse btrue btrue.
 
 Ltac compsubst := preop ; compsubst1.
 Ltac pushsubst := preop ; pushsubst1.

--- a/src/checking_tactics.v
+++ b/src/checking_tactics.v
@@ -783,6 +783,12 @@ Ltac do_try flag :=
   | DontTry => fail "Cannot try"
   end.
 
+Ltac do_shelf flag :=
+  match flag with
+  | DoShelf => idtac
+  | DontShelf => fail "Cannot shelve"
+  end.
+
 Ltac cando token :=
   match token with
   | btrue => idtac
@@ -2154,7 +2160,7 @@ Ltac magicn try shelf tysym debug :=
         assumption
       | myfail debug
       ]
-      else tryif (cando shelf)
+      else tryif (do_shelf shelf)
         then shelve
         else myfail debug
 
@@ -2195,7 +2201,7 @@ Ltac magicn try shelf tysym debug :=
         | myfail debug
         ] ; magicn try shelf tysym debug
       )
-      else tryif (cando shelf)
+      else tryif (do_shelf shelf)
         then shelve
         else myfail debug
 
@@ -2252,7 +2258,7 @@ Ltac magicn try shelf tysym debug :=
       | ceapply TyCtxConv ; [ eassumption | .. ]
       | myfail debug
       ] ; magicn try shelf btrue debug
-      else tryif (cando shelf)
+      else tryif (do_shelf shelf)
         then shelve
         else myfail debug
 
@@ -2425,12 +2431,12 @@ Ltac magicn try shelf tysym debug :=
       first [
         is_var A ; exact H
       | is_var B ; exact H'
-      | cando shelf ; shelve
+      | do_shelf shelf ; shelve
       ]
     | |- isterm ?G ?u ?A =>
       tryif (is_evar u)
       (* If u is an existential variable we don't touch it. *)
-      then tryif (cando shelf)
+      then tryif (do_shelf shelf)
         then shelve
         else myfail debug
       else (
@@ -2445,7 +2451,7 @@ Ltac magicn try shelf tysym debug :=
           ]
         | myfail debug
         ] ; magicn try shelf btrue debug
-        else tryif (cando shelf)
+        else tryif (do_shelf shelf)
           then shelve
           else myfail debug
       )
@@ -2471,7 +2477,7 @@ Ltac magicn try shelf tysym debug :=
       | capply CtxSym ; [ assumption | .. ]
       | myfail debug
       ] ; magicn try shelf btrue debug
-      else tryif (cando shelf)
+      else tryif (do_shelf shelf)
         then shelve
         else myfail debug
 
@@ -2712,7 +2718,7 @@ Ltac magicn try shelf tysym debug :=
         ] ; magicn try shelf btrue debug
       )
       else tryif (is_evar A || is_evar B)
-        then tryif (cando shelf)
+        then tryif (do_shelf shelf)
           then shelve
           else myfail debug
         else myfail debug
@@ -2761,7 +2767,7 @@ Ltac magicn try shelf tysym debug :=
             else first [
               pushsubst1
             | ceapply EqSym ; [ pushsubst1 | .. ]
-            | cando shelf ; shelve
+            | do_shelf shelf ; shelve
             ] ; magicn try shelf btrue debug
           | _ =>
             first [
@@ -2787,11 +2793,11 @@ Ltac magicn try shelf tysym debug :=
               ] ; magicn try shelf btrue debug
             else first [
               pushsubst1
-            | cando shelf ; shelve
+            | do_shelf shelf ; shelve
             ] ; magicn try shelf btrue debug
 
           | ?v =>
-            tryif (is_evar v ; cando shelf)
+            tryif (is_evar v ; do_shelf shelf)
             then shelve
             else first [
               simplify
@@ -2802,7 +2808,7 @@ Ltac magicn try shelf tysym debug :=
       )
       else first [
         pushsubst1
-      | cando shelf ; shelve
+      | do_shelf shelf ; shelve
       ] ; magicn try shelf btrue debug
     | |- eqterm ?G ?u (subst ?v ?sbs) ?A =>
       (* We know how to deal with the symmetric case. *)
@@ -2922,7 +2928,7 @@ Ltac magicn try shelf tysym debug :=
       | myfail debug
       ] ; magicn try shelf btrue debug
       else tryif (is_evar u + is_evar v)
-        then tryif (cando shelf)
+        then tryif (do_shelf shelf)
           then shelve
           else myfail debug
         else myfail debug
@@ -2934,10 +2940,10 @@ Ltac magicn try shelf tysym debug :=
 
 Ltac preop := unfold Arrow in *.
 
-Ltac magic       := preop ; magicn DontTry btrue  btrue btrue.
-Ltac okmagic     := preop ; magicn DontTry btrue  btrue bfalse.
-Ltac trymagic    := preop ; magicn DoTry   btrue  btrue bfalse.
-Ltac strictmagic := preop ; magicn DontTry bfalse btrue btrue.
+Ltac magic       := preop ; magicn DontTry DoShelf   btrue btrue.
+Ltac okmagic     := preop ; magicn DontTry DoShelf   btrue bfalse.
+Ltac trymagic    := preop ; magicn DoTry   DoShelf   btrue bfalse.
+Ltac strictmagic := preop ; magicn DontTry DontShelf btrue btrue.
 
 Ltac compsubst := preop ; compsubst1.
 Ltac pushsubst := preop ; pushsubst1.

--- a/src/checking_tactics.v
+++ b/src/checking_tactics.v
@@ -5,12 +5,6 @@ Require Import config_tactics.
 Require Import tt.
 Require Import syntax.
 
-(* We use these notations to prevent true and false of type term from shadowing
-   the boolean constructors.
- *)
-Notation "'btrue'" := (Coq.Init.Datatypes.true).
-Notation "'bfalse'" := (Coq.Init.Datatypes.false).
-
 (* Configuration options for the tactics. *)
 Inductive magic_try := DoTry | DontTry.
 Inductive magic_doshelf := DoShelf | DontShelf.
@@ -2086,22 +2080,22 @@ Ltac eqtype_subst G A sbs B k try shelf tysym debug :=
           then first [
             ceapply CongTySubst
           | myfail debug
-          ] ; k try shelf btrue debug
+          ] ; k try shelf DoTysym debug
           else first [
             ceapply EqTySym ; [ simplify | .. ]
           | ceapply CongTySubst
           | myfail debug
-          ] ; k try shelf btrue debug
+          ] ; k try shelf DoTysym debug
         )
         else first [
           pushsubst1
         | myfail debug
-        ] ; k try shelf btrue debug
+        ] ; k try shelf DoTysym debug
       | _ =>
         first [
           ceapply CongTySubst
         | myfail debug
-        ] ; k try shelf btrue debug
+        ] ; k try shelf DoTysym debug
       end
     )
     else
@@ -2114,13 +2108,13 @@ Ltac eqtype_subst G A sbs B k try shelf tysym debug :=
             simplify
           | ceapply CongTySubst
           | myfail debug
-          ] ; k try shelf btrue debug
+          ] ; k try shelf DoTysym debug
           else first [
             simplify
           | ceapply EqTySym ; [ simplify | .. ]
           | ceapply CongTySubst
           | myfail debug
-          ] ; k try shelf btrue debug
+          ] ; k try shelf DoTysym debug
         )
         else first [
           (* Should we simplify on the left first? *)
@@ -2128,20 +2122,20 @@ Ltac eqtype_subst G A sbs B k try shelf tysym debug :=
         | simplify
         | do_tysym tysym ; ceapply EqTySym ; [ simplify | .. ]
         | myfail debug
-        ] ; k try shelf btrue debug
+        ] ; k try shelf DoTysym debug
       | _ =>
         first [
           simplify
         | ceapply CongTySubst
         | myfail debug
-        ] ; k try shelf btrue debug
+        ] ; k try shelf DoTysym debug
       end
   )
   else first [
     pushsubst1
   | do_tysym tysym ; ceapply EqTySym ; [ simplify | .. ]
   | myfail debug
-  ] ; k try shelf btrue debug.
+  ] ; k try shelf DoTysym debug.
 
 (* Magic Tactic *)
 (* It is basically a type checker that doesn't do the smart things,

--- a/src/checking_tactics.v
+++ b/src/checking_tactics.v
@@ -15,6 +15,7 @@ Notation "'bfalse'" := (Coq.Init.Datatypes.false).
 Inductive magic_try := DoTry | DontTry.
 Inductive magic_doshelf := DoShelf | DontShelf.
 Inductive magic_dotysym := DoTysym | DontTysym.
+Inductive magic_doeqsym := DoEqsym | DontEqsym.
 Inductive macic_debug := DoDebug | DontDebug.
 
 Section Checking1.
@@ -789,12 +790,23 @@ Ltac do_shelf flag :=
   | DontShelf => fail "Cannot shelve"
   end.
 
-Ltac cando token :=
-  match token with
-  | btrue => idtac
-  | bfalse => fail "Cannot do" token
+Ltac do_tysym flag :=
+  match flag with
+  | DoTysym => idtac
+  | DontTysym => fail "Cannot do TySym"
   end.
 
+Ltac do_eqsym flag :=
+  match flag with
+  | DoEqsym => idtac
+  | DontEqsym => fail "Cannot do EqSym"
+  end.
+
+Ltac do_debug flag :=
+  match flag with
+  | DoDebug => idtac
+  | DontDebug => fail "Cannot debug"
+  end.
 
 (* Some tactic to push substitutions inside one step. *)
 (* Partial for now. *)
@@ -807,7 +819,7 @@ Ltac prepushsubst1 sym :=
     ceapply EqTyTrans ; [
       ceapply CongTySubst ; [
         ceapply SubstRefl
-      | prepushsubst1 btrue
+      | prepushsubst1 DoEqsym
       | ..
       ]
     | ..
@@ -1206,13 +1218,13 @@ Ltac prepushsubst1 sym :=
     ]
   (* Instead of writing all symmetry cases *)
   | |- eqterm ?G ?u ?v ?A =>
-    tryif (cando sym)
-    then ceapply EqSym ; [ prepushsubst1 bfalse | .. ]
+    tryif (do_eqsym sym)
+    then ceapply EqSym ; [ prepushsubst1 DontEqsym | .. ]
     else fail "Not a goal handled by pushsubst: eqterm" G u v A
   | |- ?G => fail "Not a goal handled by pushsubst" G
   end.
 
-Ltac pushsubst1 := prepushsubst1 btrue.
+Ltac pushsubst1 := prepushsubst1 DoEqsym.
 
 Section Checking3.
 
@@ -2050,10 +2062,10 @@ Ltac check_goal :=
   end.
 
 (* My own tactic to fail with the goal information. *)
-Ltac myfail debug :=
+Ltac myfail flag :=
   lazymatch goal with
   | |- ?G =>
-    tryif (cando debug)
+    tryif (do_debug flag)
     then fail 1000 "Cannot solve subgoal" G
     else fail "Cannot solve subgoal" G
   | _ => fail "This shouldn't happen!"
@@ -2114,7 +2126,7 @@ Ltac eqtype_subst G A sbs B k try shelf tysym debug :=
           (* Should we simplify on the left first? *)
           pushsubst1
         | simplify
-        | cando tysym ; ceapply EqTySym ; [ simplify | .. ]
+        | do_tysym tysym ; ceapply EqTySym ; [ simplify | .. ]
         | myfail debug
         ] ; k try shelf btrue debug
       | _ =>
@@ -2127,7 +2139,7 @@ Ltac eqtype_subst G A sbs B k try shelf tysym debug :=
   )
   else first [
     pushsubst1
-  | cando tysym ; ceapply EqTySym ; [ simplify | .. ]
+  | do_tysym tysym ; ceapply EqTySym ; [ simplify | .. ]
   | myfail debug
   ] ; k try shelf btrue debug.
 
@@ -2153,7 +2165,7 @@ Ltac magicn try shelf tysym debug :=
     | |- isctx ctxempty =>
       capply CtxEmpty
     | |- isctx (ctxextend ?G ?A) =>
-      ceapply CtxExtend ; magicn try shelf btrue debug
+      ceapply CtxExtend ; magicn try shelf DoTysym debug
     | |- isctx ?G =>
       tryif (is_var G)
       then first [
@@ -2170,29 +2182,29 @@ Ltac magicn try shelf tysym debug :=
         ceapply SubstZero
       | ceapply SubstCtxConv ; [ ceapply SubstZero | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- issubst (sbweak _) ?G1 ?G2 =>
       first [
         ceapply SubstWeak
       | ceapply SubstCtxConv ; [ ceapply SubstWeak | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- issubst (sbshift _ ?sbs) ?G1 ?G2 =>
       first [
         ceapply SubstShift
       | ceapply SubstCtxConv ; [ ceapply SubstShift | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- issubst sbid ?G1 ?G2 =>
       first [
         ceapply SubstId
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- issubst (sbcomp ?sbt ?sbs) ?G1 ?G2 =>
       first [
         ceapply SubstComp
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- issubst ?sbs ?G1 ?G2 =>
       tryif (is_var sbs) then (
         first [
@@ -2210,54 +2222,54 @@ Ltac magicn try shelf tysym debug :=
       first [
         ceapply TySubst
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- istype ?G (Prod ?A ?B) =>
       first [
         ceapply TyProd
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- istype ?G (Id ?A ?u ?v) =>
       first [
         ceapply TyId
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- istype ?G Empty =>
       first [
         ceapply TyEmpty
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- istype ?G Unit =>
       first [
         ceapply TyUnit
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- istype ?G Bool =>
       first [
         ceapply TyBool
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- istype ?G (SimProd ?A ?B) =>
       first [
         ceapply TySimProd
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- istype ?G (Uni ?n) =>
       first [
         ceapply TyUni
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- istype ?G (El ?l ?a) =>
       first [
         ceapply TyEl
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- istype ?G ?A =>
       tryif (is_var A)
       then first [
         eassumption
       | ceapply TyCtxConv ; [ eassumption | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
       else tryif (do_shelf shelf)
         then shelve
         else myfail debug
@@ -2271,19 +2283,19 @@ Ltac magicn try shelf tysym debug :=
         | ..
         ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm (ctxextend ?G ?A) (var 0) ?T =>
       first [
         ceapply TermVarZero
       | ceapply TermTyConv ; [ ceapply TermVarZero | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm (ctxextend ?G ?B) (var (S ?k)) ?A =>
       first [
         ceapply TermVarSucc
       | ceapply TermTyConv ; [ ceapply TermVarSucc | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (var ?k) ?A =>
       (* In that case, we might shelve, if the don't know the context. *)
       tryif (is_evar G)
@@ -2297,133 +2309,133 @@ Ltac magicn try shelf tysym debug :=
         ceapply TermAbs
       | ceapply TermTyConv ; [ ceapply TermAbs | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (app ?u ?A ?B ?v) ?C =>
       first [
         ceapply TermApp
       | ceapply TermTyConv ; [ ceapply TermApp | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (refl ?A ?u) ?B =>
       first [
         ceapply TermRefl
       | ceapply TermTyConv ; [ ceapply TermRefl | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (j ?A ?u ?C ?w ?v ?p) ?T =>
       first [
         ceapply TermJ
       | ceapply TermTyConv ; [ ceapply TermJ | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (exfalso ?A ?u) _ =>
       first [
         ceapply TermExfalso
       | ceapply TermTyConv ; [ ceapply TermExfalso | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G unit ?A =>
       first [
         ceapply TermUnit
       | ceapply TermTyConv ; [ ceapply TermUnit | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G true ?A =>
       first [
         ceapply TermTrue
       | ceapply TermTyConv ; [ ceapply TermTrue | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G false ?A =>
       first [
         ceapply TermFalse
       | ceapply TermTyConv ; [ ceapply TermFalse | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (cond ?C ?u ?v ?w) ?T =>
       first [
         ceapply TermCond
       | ceapply TermTyConv ; [ ceapply TermCond | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (pair ?A ?B ?u ?v) ?T =>
       first [
         ceapply TermPair
       | ceapply TermTyConv ; [ ceapply TermPair | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (proj1 ?A ?B ?p) ?T =>
       first [
         ceapply TermProjOne
       | ceapply TermTyConv ; [ ceapply TermProjOne | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (proj2 ?A ?B ?p) ?T =>
       first [
         ceapply TermProjTwo
       | ceapply TermTyConv ; [ ceapply TermProjTwo | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (uniProd ?l prop ?a ?b) ?T =>
       first [
         ceapply TermUniProdProp
       | ceapply TermTyConv ; [ ceapply TermUniProdProp | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (uniProd ?n ?m ?a ?b) ?T =>
       first [
         ceapply TermUniProd
       | ceapply TermTyConv ; [ ceapply TermUniProd | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (uniId ?n ?a ?u ?v) ?T =>
       first [
         ceapply TermUniId
       | ceapply TermTyConv ; [ ceapply TermUniId | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (uniEmpty ?n) ?T =>
       first [
         ceapply TermUniEmpty
       | ceapply TermTyConv ; [ ceapply TermUniEmpty | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (uniUnit ?n) ?T =>
       first [
         ceapply TermUniUnit
       | ceapply TermTyConv ; [ ceapply TermUniUnit | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (uniBool ?n) ?T =>
       first [
         ceapply TermUniBool
       | ceapply TermTyConv ; [ ceapply TermUniBool | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (uniSimProd prop prop ?a ?b) ?T =>
       first [
         ceapply TermUniSimProdProp
       | ceapply TermTyConv ; [ ceapply TermUniSimProdProp | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (uniSimProd ?n ?m ?a ?b) ?T =>
       first [
         ceapply TermUniSimProd
       | ceapply TermTyConv ; [ ceapply TermUniSimProd | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (uniUni prop) ?T =>
       first [
         ceapply TermUniProp
       | ceapply TermTyConv ; [ ceapply TermUniProp | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- isterm ?G (uniUni ?n) ?T =>
       first [
         ceapply TermUniUni
       | ceapply TermTyConv ; [ ceapply TermUniUni | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | [ H : isterm ?G ?v ?A, H' : isterm ?G ?v ?B |- isterm ?G ?v ?C ] =>
       (* We have several options so we don't take any risk. *)
       (* Eventually this should go away. I don't want to do the assert thing
@@ -2450,7 +2462,7 @@ Ltac magicn try shelf tysym debug :=
           | ..
           ]
         | myfail debug
-        ] ; magicn try shelf btrue debug
+        ] ; magicn try shelf DoTysym debug
         else tryif (do_shelf shelf)
           then shelve
           else myfail debug
@@ -2464,19 +2476,19 @@ Ltac magicn try shelf tysym debug :=
         ceapply EqCtxExtend
       | capply CtxSym ; [ ceapply EqCtxExtend | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqctx ?G ?G =>
       first [
         ceapply CtxRefl
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqctx ?G ?D =>
       tryif (is_var G ; is_var D)
       then first [
         assumption
       | capply CtxSym ; [ assumption | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
       else tryif (do_shelf shelf)
         then shelve
         else myfail debug
@@ -2487,36 +2499,36 @@ Ltac magicn try shelf tysym debug :=
       first [
         ceapply WeakNat
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqsubst (sbcomp ?sbs (sbweak _))
                 (sbcomp (sbweak _) (sbshift _ ?sbs)) ?G ?D =>
       first [
         ceapply SubstSym ; [ ceapply WeakNat | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqsubst (sbzero _ ?u1) (sbzero _ ?u2) ?D ?E =>
       first [
         ceapply CongSubstZero
       | ceapply EqSubstCtxConv ; [ ceapply CongSubstZero | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqsubst (sbweak _) (sbweak _) ?D ?E =>
       first [
         ceapply CongSubstWeak
       | ceapply EqSubstCtxConv ; [ ceapply CongSubstWeak | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqsubst (sbshift _ ?sbs1) (sbshift _ ?sbs2) ?D ?E =>
       first [
         ceapply CongSubstShift
       | ceapply EqSubstCtxConv ; [ ceapply CongSubstShift | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqsubst ?sbs ?sbs ?G ?D =>
       first [
           ceapply SubstRefl
         | myfail debug
-        ] ; magicn try shelf btrue debug
+        ] ; magicn try shelf DoTysym debug
     (* In case we have syntactically equal substitutions involved,
        we can make a little shortcut. *)
     (* | |- eqsubst (sbcomp ?sbs _) (sbcomp ?sbs _) _ _ => *)
@@ -2527,7 +2539,7 @@ Ltac magicn try shelf tysym debug :=
     (*     | .. *)
     (*     ] *)
     (*   | myfail debug *)
-    (*   ] ; magicn try shelf btrue debug *)
+    (*   ] ; magicn try shelf DoTysym debug *)
     (* | |- eqsubst (sbcomp _ ?sbs) (sbcomp _ ?sbs) _ _ => *)
     (*   first [ *)
     (*     eapply CongSubstComp ; [ *)
@@ -2535,7 +2547,7 @@ Ltac magicn try shelf tysym debug :=
     (*     | .. *)
     (*     ] *)
     (*   | myfail debug *)
-    (*   ] ; magicn try shelf btrue debug *)
+    (*   ] ; magicn try shelf DoTysym debug *)
     (* We need to simplify if we are ever going to apply congruence for
        composition. *)
     | |- eqsubst ?sbs ?sbt ?G ?D =>
@@ -2549,25 +2561,25 @@ Ltac magicn try shelf tysym debug :=
         | ..
         ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
       else first [
         ceapply SubstTrans ; [ simplify_subst | .. ]
       | ceapply SubstSym ; [ ceapply SubstTrans ; [ simplify_subst | .. ] | .. ]
       | ceapply CongSubstComp
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
 
     (*! Equality of types !*)
     | |- eqtype ?G (Subst (Subst ?A ?sbs) ?sbt) ?B =>
       first [
         compsubst1
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqtype ?G ?A (Subst (Subst ?B ?sbs) ?sbt) =>
       first [
         compsubst1
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     (* A weird case perhaps. *)
     | |- eqtype ?G (Subst ?A (sbshift ?A2 ?sbs))
                (Subst ?B' (sbcomp ?sbs (sbweak (Subst ?A1 ?sbs)))) =>
@@ -2576,7 +2588,7 @@ Ltac magicn try shelf tysym debug :=
         first [
           instantiate (1 := (Subst B' (sbweak _)))
         | myfail debug
-        ] ; magicn try shelf btrue debug
+        ] ; magicn try shelf DoTysym debug
       )
       else eqtype_subst G A (sbshift A2 sbs)
                         (Subst B' (sbcomp sbs (sbweak (Subst A1 sbs))))
@@ -2588,7 +2600,7 @@ Ltac magicn try shelf tysym debug :=
         first [
           instantiate (1 := Subst B' (sbweak _))
         | myfail debug
-        ] ; magicn try shelf btrue debug
+        ] ; magicn try shelf DoTysym debug
       )
       else eqtype_subst G (Subst B' (sbcomp sbs (sbweak A1 sbs)))
                         (Subst A (sbshift A2 sbs))
@@ -2603,7 +2615,7 @@ Ltac magicn try shelf tysym debug :=
         first [
           instantiate (1 := Subst B' (sbweak _))
         | myfail debug
-        ] ; magicn try shelf btrue debug
+        ] ; magicn try shelf DoTysym debug
       )
       else eqtype_subst G
                         A
@@ -2619,7 +2631,7 @@ Ltac magicn try shelf tysym debug :=
         first [
           instantiate (1 := Subst B' (sbweak _))
         | myfail debug
-        ] ; magicn try shelf btrue debug
+        ] ; magicn try shelf DoTysym debug
       )
       else eqtype_subst G B' sbs
                         (Subst A (sbcomp (sbshift A1 sbs)
@@ -2634,7 +2646,7 @@ Ltac magicn try shelf tysym debug :=
         first [
           instantiate (1 := Subst (Subst A sbs) (sbweak _))
         | myfail debug
-        ] ; magicn try shelf btrue debug
+        ] ; magicn try shelf DoTysym debug
       else
         eqtype_subst G A sbs (Subst B (sbzero (Subst A sbs) (subst u sbs)))
                      magicn try shelf tysym debug
@@ -2644,7 +2656,7 @@ Ltac magicn try shelf tysym debug :=
       then first [
         instantiate (1 := Subst B (sbweak _))
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
       else eqtype_subst G A (sbzero B u) B
                         magicn try shelf tysym debug
     | |- eqtype ?G (Subst ?A ?sbs) (Subst ?A ?sbt) =>
@@ -2653,53 +2665,53 @@ Ltac magicn try shelf tysym debug :=
         idtac
       | eapply EqTyRefl
       | ..
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqtype ?G (Subst ?A ?sbs) ?B =>
       (* We should push only if it makes sense. *)
       eqtype_subst G A sbs B magicn try shelf tysym debug
     | |- eqtype ?G ?A (Subst ?B ?sbs) =>
       (* We know how to deal with the symmetric case. *)
-      tryif (cando tysym)
+      tryif (do_tysym tysym)
       then ceapply EqTySym ; [
-        magicn try shelf bfalse debug
-      | magicn try shelf btrue debug ..
+        magicn try shelf DontTysym debug
+      | magicn try shelf DoTysym debug ..
       ]
       else myfail debug
     | |- eqtype ?G (Id ?A ?u ?v) (Id ?B ?w ?z) =>
       first [
         ceapply CongId
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqtype ?G (Prod ?A ?B) (Prod ?C ?D) =>
       first [
         ceapply CongProd
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqtype ?G Unit Unit =>
       first [
         ceapply EqTyRefl
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqtype ?G Bool Bool =>
       first [
         ceapply EqTyRefl
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqtype ?G (SimProd _ _) (SimProd _ _) =>
       first [
         ceapply CongSimProd
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqtype ?G (Uni _) (Uni _) =>
       first [
         ceapply EqTyRefl
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqtype ?G (El ?l ?a) (El ?l' ?b) =>
       first [
         ceapply CongEl
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqtype ?G ?A ?B =>
       tryif (is_var A ; is_var B)
       then (
@@ -2715,7 +2727,7 @@ Ltac magicn try shelf tysym debug :=
           | ..
           ]
         | myfail debug
-        ] ; magicn try shelf btrue debug
+        ] ; magicn try shelf DoTysym debug
       )
       else tryif (is_evar A || is_evar B)
         then tryif (do_shelf shelf)
@@ -2728,12 +2740,12 @@ Ltac magicn try shelf tysym debug :=
       first [
         compsubst1
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G ?u (subst (subst ?v ?sbs) ?sbt) ?A =>
       first [
         compsubst1
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (subst ?u ?sbs) ?v ?A =>
       (* Maybe some type conversion somewhere. *)
       tryif (is_var u)
@@ -2753,7 +2765,7 @@ Ltac magicn try shelf tysym debug :=
                 ]
               | eassumption
               | myfail debug
-              ] ; magicn try shelf btrue debug
+              ] ; magicn try shelf DoTysym debug
               else first [
                 ceapply EqSym ; [ simplify | .. ]
               | ceapply CongTermSubst
@@ -2762,13 +2774,13 @@ Ltac magicn try shelf tysym debug :=
                 | ..
                 ]
               | myfail debug
-              ] ; magicn try shelf btrue debug
+              ] ; magicn try shelf DoTysym debug
             )
             else first [
               pushsubst1
             | ceapply EqSym ; [ pushsubst1 | .. ]
             | do_shelf shelf ; shelve
-            ] ; magicn try shelf btrue debug
+            ] ; magicn try shelf DoTysym debug
           | _ =>
             first [
               ceapply CongTermSubst
@@ -2778,7 +2790,7 @@ Ltac magicn try shelf tysym debug :=
               ]
             | eassumption
             | myfail debug
-            ] ; magicn try shelf btrue debug
+            ] ; magicn try shelf DoTysym debug
           end
         )
         else (
@@ -2790,11 +2802,11 @@ Ltac magicn try shelf tysym debug :=
               | ceapply CongTermSubst
               | ceapply EqTyConv ; [ ceapply CongTermSubst | .. ]
               | myfail debug
-              ] ; magicn try shelf btrue debug
+              ] ; magicn try shelf DoTysym debug
             else first [
               pushsubst1
             | do_shelf shelf ; shelve
-            ] ; magicn try shelf btrue debug
+            ] ; magicn try shelf DoTysym debug
 
           | ?v =>
             tryif (is_evar v ; do_shelf shelf)
@@ -2802,37 +2814,37 @@ Ltac magicn try shelf tysym debug :=
             else first [
               simplify
             | myfail debug
-            ] ; magicn try shelf btrue debug
+            ] ; magicn try shelf DoTysym debug
           end
         )
       )
       else first [
         pushsubst1
       | do_shelf shelf ; shelve
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G ?u (subst ?v ?sbs) ?A =>
       (* We know how to deal with the symmetric case. *)
-      tryif (cando tysym)
+      tryif (do_tysym tysym)
       then ceapply EqSym ; [
-        magicn try shelf bfalse debug
-      | magicn try shelf btrue debug ..
+        magicn try shelf DontTysym debug
+      | magicn try shelf DoTysym debug ..
       ]
       else myfail debug
     | |- eqterm ?G ?u ?u ?A =>
       first [
         ceapply EqRefl
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G ?u ?v Empty =>
       first [
         config eapply @EqTermExfalso with (w := u)
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G ?u ?v Unit =>
       first [
         ceapply UnitEta
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     (* Where should ProdBeta be handled? *)
     (* Same for CondTrue, CondFalse, JRefl *)
     (* ProdEta should come in after CongApp and CongProd probably *)
@@ -2841,79 +2853,79 @@ Ltac magicn try shelf tysym debug :=
         ceapply CongAbs
       | ceapply EqTyConv ; [ ceapply CongAbs | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (app ?u1 ?A1 ?A2 ?u2) (app ?v1 ?B1 ?B2 ?v2) _ =>
       first [
         ceapply CongApp
       | ceapply EqTyConv ; [ ceapply CongApp | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (refl ?A1 ?u1) (refl ?A2 ?u2) _ =>
       first [
         ceapply CongRefl
       | ceapply EqTyConv ; [ ceapply CongRefl | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (j ?A1 ?u1 ?C1 ?w1 ?v1 ?p1) (j ?A2 ?u2 ?C2 ?w2 ?v2 ?p2) _ =>
       first [
         ceapply CongJ
       | ceapply EqTyConv ; [ ceapply CongJ | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (cond ?C1 ?u1 ?v1 ?w1) (cond ?C2 ?u2 ?v2 ?w2) _ =>
       first [
         ceapply CongCond
       | ceapply EqTyConv ; [ ceapply CongCond | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (pair _ _ _ _) (pair _ _ _ _) _ =>
       first [
         ceapply CongPair
       | ceapply EqTyConv ; [ ceapply CongPair | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (proj1 _ _ _ ) (proj1 _ _ _) _ =>
       first [
         ceapply CongProjOne
       | ceapply EqTyConv ; [ ceapply CongProjOne | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (proj2 _ _ _ ) (proj2 _ _ _) _ =>
       first [
         ceapply CongProjTwo
       | ceapply EqTyConv ; [ ceapply CongProjTwo | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (uniProd _ prop _ _) (uniProd _ prop _ _) _ =>
       first [
         ceapply CongUniProdProp
       | ceapply EqTyConv ; [ ceapply CongUniProdProp | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (uniProd _ _ _ _) (uniProd _ _ _ _) _ =>
       first [
         ceapply CongUniProd
       | ceapply EqTyConv ; [ ceapply CongUniProd | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (uniId _ _ _ _) (uniId _ _ _ _) _ =>
       first [
         ceapply CongUniId
       | ceapply EqTyConv ; [ ceapply CongUniId | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (uniSimProd prop prop _ _) (uniSimProd prop prop _ _) _ =>
       first [
         ceapply CongUniSimProdProp
       | ceapply EqTyConv ; [ ceapply CongUniSimProdProp | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G (uniSimProd _ _ _ _) (uniSimProd _ _ _ _) _ =>
       first [
         ceapply CongUniSimProd
       | ceapply EqTyConv ; [ ceapply CongUniSimProd | .. ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
     | |- eqterm ?G ?u ?v ?A =>
       tryif (is_var u ; is_var v)
       then first [
@@ -2926,7 +2938,7 @@ Ltac magicn try shelf tysym debug :=
         | ..
         ]
       | myfail debug
-      ] ; magicn try shelf btrue debug
+      ] ; magicn try shelf DoTysym debug
       else tryif (is_evar u + is_evar v)
         then tryif (do_shelf shelf)
           then shelve
@@ -2940,10 +2952,10 @@ Ltac magicn try shelf tysym debug :=
 
 Ltac preop := unfold Arrow in *.
 
-Ltac magic       := preop ; magicn DontTry DoShelf   btrue btrue.
-Ltac okmagic     := preop ; magicn DontTry DoShelf   btrue bfalse.
-Ltac trymagic    := preop ; magicn DoTry   DoShelf   btrue bfalse.
-Ltac strictmagic := preop ; magicn DontTry DontShelf btrue btrue.
+Ltac magic       := preop ; magicn DontTry DoShelf   DoTysym DoDebug.
+Ltac okmagic     := preop ; magicn DontTry DoShelf   DoTysym DontDebug.
+Ltac trymagic    := preop ; magicn DoTry   DoShelf   DoTysym DontDebug.
+Ltac strictmagic := preop ; magicn DontTry DontShelf DoTysym DoDebug.
 
 Ltac compsubst := preop ; compsubst1.
 Ltac pushsubst := preop ; pushsubst1.


### PR DESCRIPTION
This PR cures [boolean blindness](https://existentialtype.wordpress.com/2011/03/15/boolean-blindness/) in `checking_tactics.v`. Since it already bit us once, we might as well remove it altogether.